### PR TITLE
🐛 space as a command BUG

### DIFF
--- a/podrum/server.py
+++ b/podrum/server.py
@@ -92,7 +92,7 @@ class server:
             try:
                 command_name: str = split_input[0]
                 command_args: list = split_input[1:]
-            except:
+            except Exception as e:
                 command_name: str = ""
                 command_args: list = []
             if self.managers.command_manager.has_command(command_name):

--- a/podrum/server.py
+++ b/podrum/server.py
@@ -89,8 +89,12 @@ class server:
     def dispatch_command(self, user_input: str, sender: object) -> None:
         if len(user_input) > 0:
             split_input: list = user_input.split()
-            command_name: str = split_input[0]
-            command_args: list = split_input[1:]
+            try:
+                command_name: str = split_input[0]
+                command_args: list = split_input[1:]
+            except:
+                command_name: str = ""
+                command_args: list = []
             if self.managers.command_manager.has_command(command_name):
                 self.managers.command_manager.execute(command_name, command_args, sender)
             else:


### PR DESCRIPTION
Easy way to fix "space command" bug
If you give space as command in console, server throw error and freeze.